### PR TITLE
Add the register page for the app

### DIFF
--- a/lib/ratemynews/broadcasters.ex
+++ b/lib/ratemynews/broadcasters.ex
@@ -17,4 +17,30 @@ defmodule Ratemynews.Broadcasters do
     Repo.all(Broadcaster)
     |> Repo.preload(:votes)
   end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking broadcaster changes.
+  It can be used for creating or updating a broadcaster.
+  """
+  def change_broadcaster(%Broadcaster{} = broadcaster, attrs \\ %{}) do
+    Broadcaster.changeset(broadcaster, attrs)
+  end
+
+  @doc """
+  Creates a broadcaster.
+
+  ## Examples
+
+      iex> create_broadcaster(%{name: "Some Name"})
+      {:ok, %Broadcaster{}}
+
+      iex> create_broadcaster(%{name: nil})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_broadcaster(attrs \\ %{}) do
+    %Broadcaster{}
+    |> Broadcaster.changeset(attrs)
+    |> Repo.insert()
+  end
 end

--- a/lib/ratemynews/broadcasters/broadcaster.ex
+++ b/lib/ratemynews/broadcasters/broadcaster.ex
@@ -1,4 +1,3 @@
-
 defmodule Ratemynews.Broadcasters.Broadcaster do
   use Ecto.Schema
   import Ecto.Changeset
@@ -20,6 +19,8 @@ defmodule Ratemynews.Broadcasters.Broadcaster do
   def changeset(broadcaster, attrs) do
     broadcaster
     |> cast(attrs, [:name, :mode_of_broadcast, :origin, :topics, :profile_image_url, :social_media])
-    |> validate_required([:name, :mode_of_broadcast, :origin, :topics, :social_media])
+    |> validate_required([:name, :mode_of_broadcast, :origin, :topics])
+    |> unique_constraint(:name, name: :unique_broadcaster)  # Composite unique constraint
+    |> validate_length(:name, min: 3)
   end
 end

--- a/lib/ratemynews_web/controllers/broadcaster_controller.ex
+++ b/lib/ratemynews_web/controllers/broadcaster_controller.ex
@@ -1,0 +1,24 @@
+defmodule RatemynewsWeb.BroadcasterController do
+  use RatemynewsWeb, :controller
+
+  alias Ratemynews.Broadcasters
+  alias Ratemynews.Broadcasters.Broadcaster
+
+  def new(conn, _params) do
+    changeset = Broadcasters.change_broadcaster(%Broadcaster{},%{})
+    IO.inspect(changeset)
+    render(conn, :broadcaster, changeset: changeset)
+  end
+
+  def create(conn, %{"broadcaster" => broadcaster_params}) do
+    case Broadcasters.create_broadcaster(broadcaster_params) do
+      {:ok, _broadcaster} ->
+        conn
+        |> put_flash(:info, "Broadcaster created successfully.")
+        |> redirect(to: "/home")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :broadcaster, changeset: changeset)
+    end
+  end
+end

--- a/lib/ratemynews_web/controllers/broadcaster_html.ex
+++ b/lib/ratemynews_web/controllers/broadcaster_html.ex
@@ -1,0 +1,10 @@
+defmodule RatemynewsWeb.BroadcasterHTML do
+  @moduledoc """
+  This module contains pages rendered by BroadcasterController.
+
+  See the `broadcaster_html` directory for all templates available.
+  """
+  use RatemynewsWeb, :html
+
+  embed_templates "broadcaster_html/*"
+end

--- a/lib/ratemynews_web/controllers/broadcaster_html/broadcaster.html.heex
+++ b/lib/ratemynews_web/controllers/broadcaster_html/broadcaster.html.heex
@@ -1,0 +1,22 @@
+<h1 class="text-2xl font-bold mb-6">Register a New Broadcaster</h1>
+<.form :let={f} for={@changeset} action={~p"/register"} class="space-y-6">
+  <div class="flex flex-col space-y-2">
+    <.input field={f[:name]} label="Name" class="p-2 border rounded-md" />
+  </div>
+  
+  <div class="flex flex-col space-y-2">
+    <.input field={f[:mode_of_broadcast]} label="Mode of Broadcast" class="p-2 border rounded-md" />
+  </div>
+  
+  <div class="flex flex-col space-y-2">
+    <.input field={f[:origin]} label="Origin" class="p-2 border rounded-md" />
+  </div>
+  
+  <div class="flex flex-col space-y-2">
+    <.input field={f[:topics]} label="Topics" class="p-2 border rounded-md" />
+  </div>
+  
+  <div>
+    <.button type="submit" class="w-full bg-blue-500 text-white p-2 rounded-md hover:bg-blue-600">Register</.button>
+  </div>
+</.form>

--- a/lib/ratemynews_web/router.ex
+++ b/lib/ratemynews_web/router.ex
@@ -22,6 +22,8 @@ pipe_through [:browser, :require_authenticated_user]
 
     get "/", PageController, :home
     get "/home", HomeController, :index
+    get "/register", BroadcasterController, :new
+    post "/register", BroadcasterController, :create
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## What: 

Add the `/register` page for the app 

## How: 
- [X] Add the routes for the `/register` 
- [X] Add a form for registration with the following fields: `name`, `mode_of_broadcast`, `topics`, and `origin` 
