### PR TITLE
Add pagination for broadcasters list on the home page

### DIFF
--- a/lib/ratemynews/broadcasters.ex
+++ b/lib/ratemynews/broadcasters.ex
@@ -13,12 +13,24 @@ defmodule Ratemynews.Broadcasters do
       [%Broadcaster{}, ...]
 
   """
-  def list_broadcasters do
-    Repo.all(
-      from b in Broadcaster,
-        order_by: [desc: b.upvotes],
-        preload: [:votes]
-    )
+  def list_broadcasters(page, per_page \\ 50) do
+    Broadcaster
+    |> order_by([b], desc: b.upvotes)
+    |> limit(^per_page)
+    |> offset(^((page - 1) * per_page))
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns the total count of broadcasters
+
+  ## Examples
+
+      iex> count_broadcasters()
+      10
+  """
+  def count_broadcasters do
+   Repo.aggregate(Broadcaster, :count, :id)
   end
 
   @doc """

--- a/lib/ratemynews_web/components/broadcasters_live_component.ex
+++ b/lib/ratemynews_web/components/broadcasters_live_component.ex
@@ -6,7 +6,7 @@ defmodule RatemynewsWeb.Components.BroadcasterLiveComponent do
 
 def render(assigns) do
   ~H"""
-  <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+  <tr class="flex flex-col flex-no-wrap sm:table-row bg-white border-b dark:bg-gray-800 dark:border-gray-700">
     <td class="py-4 px-6 flex items-center">
       <%= @broadcaster.name %>
     </td>

--- a/lib/ratemynews_web/live/home_live.html.heex
+++ b/lib/ratemynews_web/live/home_live.html.heex
@@ -1,6 +1,12 @@
 <div class="container mx-auto py-8">
   <h1 class="text-4xl font-bold mb-6 text-center">Vote for your Favorite News Source</h1>
   <p class="text-lg mb-4 text-center">Who keeps you informed? Tell us your top pick.</p>
+  
+  <div class="flex justify-center mb-6">
+    <.link navigate={~p"/register"} class="text-white bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded-md shadow-md">
+      Register Broadcaster
+    </.link>
+  </div>
 
   <div class="flex items-center sm:justify-center ml-4 sm:ml-0">
     <table class="min-w-full text-sm text-left text-gray-500 dark:text-gray-400">

--- a/lib/ratemynews_web/live/home_live.html.heex
+++ b/lib/ratemynews_web/live/home_live.html.heex
@@ -11,7 +11,7 @@
   <div class="flex items-center sm:justify-center ml-4 sm:ml-0">
     <table class="min-w-full text-sm text-left text-gray-500 dark:text-gray-400">
       <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-        <tr class="flex flex-col flex-no wrap sm:table-row">
+        <tr class="flex flex-col flex-no-wrap sm:table-row">
           <th scope="col" class="py-3 px-6">Broadcaster</th>
           <th scope="col" class="py-3 px-6">Mode of Broadcast</th>
           <th scope="col" class="py-3 px-6">Origin</th>

--- a/lib/ratemynews_web/live/home_live.html.heex
+++ b/lib/ratemynews_web/live/home_live.html.heex
@@ -33,4 +33,30 @@
       </tbody>
     </table>
   </div>
+
+<div class="flex justify-center mt-4">
+  <button phx-click="change_page" phx-value-page={@page - 1} 
+          class={
+            if @page <= 1 do
+              "text-gray-500 cursor-not-allowed"
+            else
+              "text-blue-500 hover:underline"
+            end
+          } 
+          disabled={@page <= 1}>
+    Previous
+  </button>
+  <span class="mx-4">|</span>
+  <button phx-click="change_page" phx-value-page={@page + 1} 
+          class={
+            if @page * @per_page >= @total_count do
+              "text-gray-500 cursor-not-allowed"
+            else
+              "text-blue-500 hover:underline"
+            end
+          } 
+          disabled={@page * @per_page >= @total_count}>
+    Next
+  </button>
+</div>
 </div>


### PR DESCRIPTION
## What 
Add pagination for broadcasters list on the home page

## Why 
The list of broadcasters might grow long, rendering it in a single go would be impact both the performance of the server and the client. 

## How
- [X] Add limit and offset in list_broadcasters function based on page size
- [X] Add function count_broadcasters which returns number of broadcasters
- [X] Add variables page, per_page, and total_count to the socket on mount
- [X] Add event handle for changing page
- [X] Update total count in event handlers of adding new broadcasters
- [X] Add next and previous button on the home page

## Anything Else: 
- Add `Register Broadcaster` button for the `/register` route on the home page
- Fix the CSS for the tables