### PR TITLE
Update routing for registration flow

### DIFF
--- a/lib/ratemynews_web/live/user_confirmation_live.ex
+++ b/lib/ratemynews_web/live/user_confirmation_live.ex
@@ -36,7 +36,7 @@ defmodule RatemynewsWeb.UserConfirmationLive do
         {:noreply,
          socket
          |> put_flash(:info, "User confirmed successfully.")
-         |> redirect(to: ~p"/")}
+         |> redirect(to: ~p"/users/log_in")}
 
       :error ->
         # If there is a current user and the account was already confirmed,

--- a/lib/ratemynews_web/live/user_registration_live.ex
+++ b/lib/ratemynews_web/live/user_registration_live.ex
@@ -24,8 +24,6 @@ defmodule RatemynewsWeb.UserRegistrationLive do
         phx-submit="save"
         phx-change="validate"
         phx-trigger-action={@trigger_submit}
-        action={~p"/users/log_in?_action=registered"}
-        method="post"
       >
         <.error :if={@check_errors}>
           Oops, something went wrong! Please check the errors below.
@@ -63,7 +61,8 @@ defmodule RatemynewsWeb.UserRegistrationLive do
           )
 
         changeset = Accounts.change_user_registration(user)
-        {:noreply, socket |> assign(trigger_submit: true) |> assign_form(changeset)}
+        socket |> assign(trigger_submit: true) |> assign_form(changeset)
+        {:noreply, push_navigate(socket, to: "/users/confirm")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, socket |> assign(check_errors: true) |> assign_form(changeset)}


### PR DESCRIPTION
## What 
Update routing for registration flow:

- Route to /users/confirm once the user is registered

- Route to /users/log_in when users confirm their account

## Why

The current registration flow is confusing, it directly POSTs to log_in and fails because the user has not confirmed its account. 


